### PR TITLE
Actualizar número de provincias

### DIFF
--- a/lib/id_ecuador/id.rb
+++ b/lib/id_ecuador/id.rb
@@ -81,7 +81,7 @@ module IdEcuador
     end
 
     def evaluate_province_code
-      provinces = 22
+      provinces = 24
       code = @id[0,2].to_i
       if code < 1 || code > provinces
         @errors << "Código de provincia incorrecto"


### PR DESCRIPTION
Tenemos un bug utilizando la gema, puesto que estamos usando un RUC que comienza con número 23. Ahora existen 24 provincias en lugar de 22. Por favor, corregir.